### PR TITLE
Builds the deployment pipeline

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -22,4 +22,7 @@ enabled = true
 
   [analyzers.meta]
   runtime_version = "3.x.x"
-  
+
+[[analyzers]]
+name = "test-coverage"
+enabled = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 .pytest_cache/
 .vscode/
+bin/
 coverage/
 
 .coverage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,7 +10,7 @@ variables:
   IMAGE: registry.gitlab.com/onlinejudge95/flask-rest-container
 
 unit_test:
-  stage: unit test
+  stage: unit_test
   image: $IMAGE:latest
   services:
     - postgres:latest
@@ -26,7 +26,7 @@ unit_test:
     - ./bin/deepsource report --analyzer test-coverage --key python --value-file .coverage/xml/unit/coverage.xml
 
 functional_test:
-  stage: functional test
+  stage: functional_test
   image: $IMAGE:latest
   services:
     - postgres:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,14 +18,9 @@ test:
     POSTGRES_USER: runner
     POSTGRES_PASSWORD: ""
     DATABASE_TEST_URL: postgres://runner@postgres:5432/users
-  before_script:
-    - apk add --update curl && rm -rf /var/cache/apk/*
-    - curl https://deepsource.io/cli | sh
   script:
     - pytest app/tests/unit/* --cov-report xml:coverage/xml/unit
-    - ./bin/deepsource report --analyzer test-coverage --key python --value-file .coverage/xml/unit/coverage.xml
     - pytest app/tests/functional/* --cov-report xml:coverage/xml/functional
-    - ./bin/deepsource report --analyzer test-coverage --key python --value-file .coverage/xml/functional/coverage.xml
 
 build:
   stage: build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,45 @@
 image: docker:stable
 
 stages:
+  - unit_test
+  - functional_test
   - build
-  - test
+  - deploy
 
 variables:
   IMAGE: registry.gitlab.com/onlinejudge95/flask-rest-container
+
+unit_test:
+  stage: unit test
+  image: $IMAGE:latest
+  services:
+    - postgres:latest
+  variables:
+    POSTGRES_DB: users
+    POSTGRES_USER: runner
+    POSTGRES_PASSWORD: ""
+    DATABASE_TEST_URL: postgres://runner@postgres:5432/users
+  before_script:
+    - curl https://deepsource.io/cli | sh
+  script:
+    - pytest app/tests/unit/* --cov-report xml:coverage/xml/unit
+    - ./bin/deepsource report --analyzer test-coverage --key python --value-file .coverage/xml/unit/coverage.xml
+
+functional_test:
+  stage: functional test
+  image: $IMAGE:latest
+  services:
+    - postgres:latest
+  variables:
+    POSTGRES_DB: users
+    POSTGRES_USER: runner
+    POSTGRES_PASSWORD: ""
+    DATABASE_TEST_URL: postgres://runner@postgres:5432/users
+  before_script:
+    - curl https://deepsource.io/cli | sh
+  script:
+    - pytest app/tests/unit/* --cov-report xml:coverage/xml/functional
+    - ./bin/deepsource report --analyzer test-coverage --key python --value-file .coverage/xml/functional/coverage.xml
 
 build:
   stage: build
@@ -23,15 +57,20 @@ build:
       "."
     - docker push $IMAGE:latest
 
-test:
-  stage: test
-  image: $IMAGE:latest
+deploy:
+  stage: deploy
   services:
-    - postgres:latest
+    - docker:dind
   variables:
-    POSTGRES_DB: users
-    POSTGRES_USER: runner
-    POSTGRES_PASSWORD: ""
-    DATABASE_TEST_URL: postgres://runner@postgres:5432/users
+    DOCKER_DRIVER: overlay2
+    HEROKU_APP_NAME: rest-container-staging
+    HEROKU_REGISTRY_IMAGE: registry.heroku.com/${HEROKU_APP_NAME}/web
   script:
-    - pytest
+    - apk add --no-cache curl
+    - docker build
+      --tag $HEROKU_REGISTRY_IMAGE
+      --file prod.Dockerfile
+      "."
+    - docker login -u _ -p $HEROKU_AUTH_TOKEN registry.heroku.com
+    - docker push $HEROKU_REGISTRY_IMAGE
+    - ./release.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,16 +1,15 @@
 image: docker:stable
 
 stages:
-  - unit_test
-  - functional_test
+  - test
   - build
   - deploy
 
 variables:
   IMAGE: registry.gitlab.com/onlinejudge95/flask-rest-container
 
-unit_test:
-  stage: unit_test
+test:
+  stage: test
   image: $IMAGE:latest
   services:
     - postgres:latest
@@ -20,25 +19,12 @@ unit_test:
     POSTGRES_PASSWORD: ""
     DATABASE_TEST_URL: postgres://runner@postgres:5432/users
   before_script:
+    - apk add --update curl && rm -rf /var/cache/apk/*
     - curl https://deepsource.io/cli | sh
   script:
     - pytest app/tests/unit/* --cov-report xml:coverage/xml/unit
     - ./bin/deepsource report --analyzer test-coverage --key python --value-file .coverage/xml/unit/coverage.xml
-
-functional_test:
-  stage: functional_test
-  image: $IMAGE:latest
-  services:
-    - postgres:latest
-  variables:
-    POSTGRES_DB: users
-    POSTGRES_USER: runner
-    POSTGRES_PASSWORD: ""
-    DATABASE_TEST_URL: postgres://runner@postgres:5432/users
-  before_script:
-    - curl https://deepsource.io/cli | sh
-  script:
-    - pytest app/tests/unit/* --cov-report xml:coverage/xml/functional
+    - pytest app/tests/functional/* --cov-report xml:coverage/xml/functional
     - ./bin/deepsource report --analyzer test-coverage --key python --value-file .coverage/xml/functional/coverage.xml
 
 build:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 Flask-REST-Container
 ====================
 
+[![pipeline status](https://gitlab.com/onlinejudge95/Flask-REST-Container/badges/master/pipeline.svg)](https://gitlab.com/onlinejudge95/Flask-REST-Container/commits/master)

--- a/app/src/routes/ping.py
+++ b/app/src/routes/ping.py
@@ -9,7 +9,7 @@ api = Api(bp)
 class PingAPI(Resource):
     @staticmethod
     def get():
-        return {"status": "success", "message": "pong!"}
+        return {"status": "success", "message": "pong"}
 
 
 api.add_resource(PingAPI, "/ping")

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,8 @@
+IMAGE_ID=$(docker inspect ${HEROKU_REGISTRY_IMAGE} --format={{.Id}})
+PAYLOAD='{"updates": [{"type": "web", "docker_image": "'"$IMAGE_ID"'"}]}'
+
+curl -n -X PATCH https://api.heroku.com/apps/$HEROKU_APP_NAME/formation \
+  -d "${PAYLOAD}" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/vnd.heroku+json; version=3.docker-releases" \
+  -H "Authorization: Bearer ${HEROKU_AUTH_TOKEN}"

--- a/release.sh
+++ b/release.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 IMAGE_ID=$(docker inspect ${HEROKU_REGISTRY_IMAGE} --format={{.Id}})
 PAYLOAD='{"updates": [{"type": "web", "docker_image": "'"$IMAGE_ID"'"}]}'
 


### PR DESCRIPTION
Adds following enhancements over the previous version

- [x] `unit tests`, runs unit tests here and reports the **coverage** to [Deepsource](https://deepsource.io/gh/onlinejudge95/Flask-REST-Container/)
- [x] `functional tests`, runs functional tests here and reports the **coverage** to [Deepsource](https://deepsource.io/gh/onlinejudge95/Flask-REST-Container/)
- [x] `build`, checks for a build failure in`prod.Dockerfile`.
- [ ] `deploy`, deploys the release to [live](https://rest-container-staging.herokuapp.com/)